### PR TITLE
fix bug in b6222f2

### DIFF
--- a/src/solo/sportal/portal/ParticlePortal.php
+++ b/src/solo/sportal/portal/ParticlePortal.php
@@ -65,7 +65,7 @@ class ParticlePortal extends Portal implements ActivateOnSneak, Tickable{
       $this->levelInstance = null;
       return;
     }
-    $pos = new Vector3();
+    $pos = new Vector3($this->x, $this->y, $this->z);
     switch($this->particleId){
       case 25: //그라데이션 파티클
         for($i = 0; $i < self::$generateCount; $i++){


### PR DESCRIPTION
오류 로그
```
2017-08-19 [18:38:40] [Server thread/CRITICAL]: Could not execute task solo\sportal\task\PortalTickTask: Call to a member function setComponents() on null
2017-08-19 [18:38:40] [Server thread/CRITICAL]: Error: "Call to a member function setComponents() on null" (EXCEPTION) in "/SPortal-master/src/solo/sportal/portal/ParticlePortal" at line 71
```